### PR TITLE
Add accessList argument to tx sign path to support EIP-2930

### DIFF
--- a/internal/usecase/path_sign_txn_test.go
+++ b/internal/usecase/path_sign_txn_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
+	"encoding/json"
+	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 	"testing"
 
@@ -141,15 +143,26 @@ func TestBackend_signTx(t *testing.T) {
 	sender, _ = types.Sender(types.LatestSignerForChainID(big.NewInt(12345)), tx)
 	assert.Equal(t, address.Hex(), sender.Hex())
 
+	accessList := types.AccessList{types.AccessTuple{
+		Address:     common.HexToAddress("0xBffc2f3Df75367B0f246aF6Ae42AFf59A33f2704"),
+		StorageKeys: []common.Hash{common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000081")},
+	}}
+
+	encodedAccessList, err := json.Marshal(accessList)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
 	data = map[string]interface{}{
-		"input":     dataToSign,
-		"address":   "0xBffc2f3Df75367B0f246aF6Ae42AFf59A33f2704",
-		"to":        "0xf809410b0d6f047c603deb311979cd413e025a84",
-		"gas":       2500,
-		"nonce":     "0x3",
-		"gasFeeCap": "1",
-		"gasTipCap": "0",
-		"chainId":   "1",
+		"input":      dataToSign,
+		"address":    "0xBffc2f3Df75367B0f246aF6Ae42AFf59A33f2704",
+		"to":         "0xf809410b0d6f047c603deb311979cd413e025a84",
+		"gas":        2500,
+		"nonce":      "0x3",
+		"gasFeeCap":  "1",
+		"gasTipCap":  "0",
+		"chainId":    "1",
+		"accessList": encodedAccessList,
 	}
 	req.Data = data
 	resp, err = b.HandleRequest(context.Background(), req)

--- a/internal/usecase/utils.go
+++ b/internal/usecase/utils.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"crypto/ecdsa"
+	"encoding/json"
 	"errors"
 	"math/big"
 	"regexp"
@@ -21,6 +22,7 @@ type Nonce struct {
 }
 
 func newTransactionWithDynamicFee(
+	chainId *big.Int,
 	to *common.Address,
 	nonce uint64,
 	gasFeeCap *big.Int,
@@ -28,15 +30,18 @@ func newTransactionWithDynamicFee(
 	gas uint64,
 	data []byte,
 	value *big.Int,
+	accessList types.AccessList,
 ) *types.Transaction {
 	return types.NewTx(&types.DynamicFeeTx{
-		To:        to,
-		Nonce:     nonce,
-		GasFeeCap: gasFeeCap,
-		GasTipCap: gasTipCap,
-		Gas:       gas,
-		Value:     value,
-		Data:      data,
+		ChainID:    chainId,
+		To:         to,
+		Nonce:      nonce,
+		GasFeeCap:  gasFeeCap,
+		GasTipCap:  gasTipCap,
+		Gas:        gas,
+		Value:      value,
+		Data:       data,
+		AccessList: accessList,
 	})
 }
 
@@ -88,4 +93,18 @@ func contains(arr []*big.Int, value *big.Int) bool {
 		}
 	}
 	return false
+}
+
+func parseAccessList(list string) (types.AccessList, error) {
+	accessList := types.AccessList{}
+	if list == "" {
+		return accessList, nil
+	}
+
+	err := json.Unmarshal([]byte(list), &accessList)
+	if err != nil {
+		return types.AccessList{}, err
+	}
+
+	return accessList, nil
 }


### PR DESCRIPTION
This PR adds a accessList parameter to the sign path to support EIP-2930. And adds the `v, r, s` to the returned data.